### PR TITLE
More cleanup data retrieval

### DIFF
--- a/covid19_inference/data_retrieval.py
+++ b/covid19_inference/data_retrieval.py
@@ -280,8 +280,8 @@ class JHU():
             else:
                 df['confirmed'] = self.confirmed[(country,state)]
         df.index.name = 'date'
-
-        return self.filter_date(df,begin_date,end_date)
+        df = self.filter_date(df,begin_date,end_date)
+        return df.drop(df.index[0])
 
     def get_new_confirmed(self, country:str = None, state:str = None, begin_date:datetime.datetime = None, end_date:datetime.datetime = None) -> pd.DataFrame:
         """
@@ -304,7 +304,20 @@ class JHU():
         : pandas.DataFrame
             table with daily new recovered cases and the date as index
         """        
-        df = self.get_confirmed(country,state,begin_date,end_date)
+        if country == "None":
+            country = None
+        if state == "None":
+            state = None
+        df = pd.DataFrame(columns=['date', 'confirmed']).set_index('date')
+        if country is None:
+            df['confirmed'] = self.confirmed.sum(axis = 1, skipna = True)
+        else:
+            if state is None:
+                df['confirmed'] = self.confirmed[country].sum(axis = 1, skipna = True)         
+            else:
+                df['confirmed'] = self.confirmed[(country,state)]
+        df.index.name = 'date'
+        df = self.filter_date(df,begin_date,end_date)
         df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
 
@@ -344,8 +357,8 @@ class JHU():
                 df['deaths'] = self.deaths[(country,state)]
         
         df.index.name = 'date'
-
-        return self.filter_date(df,begin_date,end_date)
+        df = self.filter_date(df,begin_date,end_date)
+        return df.drop(df.index[0])
 
     def get_new_deaths(self, country:str = None, state:str = None, begin_date:datetime.datetime = None, end_date:datetime.datetime = None) -> pd.DataFrame:
         """
@@ -368,7 +381,22 @@ class JHU():
         : pandas.DataFrame
             table with daily new recovered cases and the date as index
         """        
-        df = self.get_deaths(country,state,begin_date,end_date)
+        if country == "None":
+            country = None
+        if state == "None":
+            state = None
+
+        df = pd.DataFrame(columns=['date', 'deaths']).set_index('date')
+        if country is None:
+            df['deaths'] = self.deaths.sum(axis = 1, skipna = True)
+        else:
+            if state is None:
+                df['deaths'] = self.deaths[country].sum(axis = 1, skipna = True)              
+            else:
+                df['deaths'] = self.deaths[(country,state)]
+        
+        df.index.name = 'date'
+        df = self.filter_date(df,begin_date,end_date)
         df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
 
@@ -409,7 +437,8 @@ class JHU():
 
         df.index.name = 'date'
 
-        return self.filter_date(df,begin_date,end_date)
+        df = self.filter_date(df,begin_date,end_date)
+        return df.drop(df.index[0])
 
     def get_new_recovered(self, country:str = None, state:str = None, begin_date:datetime.datetime = None, end_date:datetime.datetime = None) -> pd.DataFrame:
         """
@@ -432,7 +461,23 @@ class JHU():
         : pandas.DataFrame
             table with daily new recovered cases and the date as index
         """        
-        df = self.get_recovered(country,state,begin_date,end_date)
+        if country == "None":
+            country = None
+        if state == "None":
+            state = None
+
+        df = pd.DataFrame(columns=['date', 'recovered']).set_index('date')
+        if country is None:
+            df['recovered'] = self.recovered.sum()
+        else:
+            if state is None:
+                df['recovered'] = self.recovered.loc[country].sum()              
+            else:
+                df['recovered'] = self.recovered.loc[(country,state)]
+
+        df.index.name = 'date'
+
+        df = self.filter_date(df,begin_date,end_date)
 
         df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
@@ -609,7 +654,7 @@ class RKI():
             value = landkreis
 
         df = self.filter(begin_date,end_date,'AnzahlFall',date_type,level,value)
-        return df
+        return df.drop(df.index[0])
 
     def get_new_confirmed(self, bundesland:str = None, landkreis:str = None, begin_date:datetime.datetime = None, end_date:datetime.datetime = None, date_type:str='date')-> pd.DataFrame:
         """
@@ -632,7 +677,16 @@ class RKI():
         : pandas.DataFrame
             table with daily new confirmed and the date as index
         """        
-        df = self.get_confirmed(bundesland, landkreis, begin_date, end_date, date_type)
+        level = None
+        value = None
+        if bundesland is not None:
+            level = "Bundesland"
+            value = bundesland
+        if landkreis is not None:
+            level = "Landkreis"
+            value = landkreis
+
+        df = self.filter(begin_date,end_date,'AnzahlFall',date_type,level,value)
         #Get difference to the days beforehand
         df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
@@ -668,7 +722,7 @@ class RKI():
             value = landkreis
 
         df = self.filter(begin_date,end_date,'AnzahlTodesfall',date_type,level,value)
-        return df
+        return df.drop(df.index[0])
 
     def get_new_deaths(self, bundesland:str = None, landkreis:str = None, begin_date:datetime.datetime = None, end_date:datetime.datetime = None, date_type:str='date')-> pd.DataFrame:
         """
@@ -690,8 +744,18 @@ class RKI():
         -------
         : pandas.DataFrame
             table with daily new deaths and the date as index
-        """        
-        df = self.get_deaths(bundesland, landkreis, begin_date, end_date, date_type)
+        """
+        
+        level = None
+        value = None
+        if bundesland is not None:
+            level = "Bundesland"
+            value = bundesland
+        if landkreis is not None:
+            level = "Landkreis"
+            value = landkreis
+
+        df = self.filter(begin_date,end_date,'AnzahlTodesfall',date_type,level,value)
         #Get difference to the days beforehand
         df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
@@ -728,7 +792,7 @@ class RKI():
             value = landkreis
 
         df = self.filter(begin_date,end_date,'AnzahlGenesen',date_type,level,value)
-        return df
+        return df.drop(df.index[0])
 
     def get_new_recovered(self, bundesland:str = None, landkreis:str = None, begin_date:datetime.datetime = None, end_date:datetime.datetime = None, date_type:str='date')-> pd.DataFrame:
         """
@@ -751,9 +815,17 @@ class RKI():
         : pandas.DataFrame
             table with daily new recovered cases and the date as index
         """        
-        df = self.get_recovered(bundesland, landkreis, begin_date, end_date, date_type)
+        level = None
+        value = None
+        if bundesland is not None:
+            level = "Bundesland"
+            value = bundesland
+        if landkreis is not None:
+            level = "Landkreis"
+            value = landkreis
+
+        df = self.filter(begin_date,end_date,'AnzahlGenesen',date_type,level,value)
         #Get difference to the days beforehand
-        print(df.index)
         df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
 

--- a/covid19_inference/data_retrieval.py
+++ b/covid19_inference/data_retrieval.py
@@ -303,16 +303,8 @@ class JHU():
         -------
         : pandas.DataFrame
             table with daily new recovered cases and the date as index
-        """
-        if begin_date is not None:
-            begin_date = begin_date - datetime.timedelta(days=1)
-
-        df = self.get_confirmed(bundesland, landkreis, begin_date, end_date, date_type)
-        #Get difference to the days beforehand
-
-        #append a 0 row for consistency in the shape of the data output !HACKY!
-        if begin_date is None:
-            df.loc[pd.Timestamp.min.to_pydatetime()] = 0    
+        """        
+        df = self.get_confirmed(country,state,begin_date,end_date)
         df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
 
@@ -375,17 +367,8 @@ class JHU():
         -------
         : pandas.DataFrame
             table with daily new recovered cases and the date as index
-        """
-        if begin_date is not None:
-            begin_date = begin_date - datetime.timedelta(days=1)
-
-        df = self.get_deaths(bundesland, landkreis, begin_date, end_date, date_type)
-        #Get difference to the days beforehand
-
-        #append a 0 row for consistency in the shape of the data output !HACKY!
-        if begin_date is None:
-            df.loc[pd.Timestamp.min.to_pydatetime()] = 0    
-
+        """        
+        df = self.get_deaths(country,state,begin_date,end_date)
         df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
 
@@ -448,17 +431,8 @@ class JHU():
         -------
         : pandas.DataFrame
             table with daily new recovered cases and the date as index
-        """
-        if begin_date is not None:
-            begin_date = begin_date - datetime.timedelta(days=1)
-
-        df = self.get_recovered(bundesland, landkreis, begin_date, end_date, date_type)
-        #Get difference to the days beforehand
-
-        #append a 0 row for consistency in the shape of the data output !HACKY!
-        if begin_date is None:
-            df.loc[pd.Timestamp.min.to_pydatetime()] = 0
-        #Get difference to the days beforehand
+        """        
+        df = self.get_recovered(country,state,begin_date,end_date)
 
         df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
@@ -657,16 +631,8 @@ class RKI():
         -------
         : pandas.DataFrame
             table with daily new confirmed and the date as index
-        """
-        if begin_date is not None:
-            begin_date = begin_date - datetime.timedelta(days=1)
-
-        df = self.get_deaths(bundesland, landkreis, begin_date, end_date, date_type)
-        #Get difference to the days beforehand
-
-        #append a 0 row for consistency in the shape of the data output !HACKY!
-        if begin_date is None:
-            df.loc[pd.Timestamp.min.to_pydatetime()] = 0
+        """        
+        df = self.get_confirmed(bundesland, landkreis, begin_date, end_date, date_type)
         #Get difference to the days beforehand
         df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
@@ -724,18 +690,8 @@ class RKI():
         -------
         : pandas.DataFrame
             table with daily new deaths and the date as index
-        """
-
-        if begin_date is not None:
-            begin_date = begin_date - datetime.timedelta(days=1)
-
+        """        
         df = self.get_deaths(bundesland, landkreis, begin_date, end_date, date_type)
-        #Get difference to the days beforehand
-
-        #append a 0 row for consistency in the shape of the data output !HACKY!
-        if begin_date is None:
-            df.loc[pd.Timestamp.min.to_pydatetime()] = 0
-
         #Get difference to the days beforehand
         df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
@@ -795,16 +751,9 @@ class RKI():
         : pandas.DataFrame
             table with daily new recovered cases and the date as index
         """        
-        if begin_date is not None:
-            begin_date = begin_date - datetime.timedelta(days=1)
-
         df = self.get_recovered(bundesland, landkreis, begin_date, end_date, date_type)
         #Get difference to the days beforehand
-
-        #append a 0 row for consistency in the shape of the data output !HACKY!
-        if begin_date is None:
-            df.loc[pd.Timestamp.min.to_pydatetime()] = 0
-
+        print(df.index)
         df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
 

--- a/covid19_inference/data_retrieval.py
+++ b/covid19_inference/data_retrieval.py
@@ -71,7 +71,7 @@ class JHU():
             fp_recovered = 'https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_recovered_global.csv'
         return self.download_confirmed(fp_confirmed, save_to_attributes), self.download_deaths(fp_deaths, save_to_attributes), self.download_recovered(fp_recovered, save_to_attributes)
 
-    def download_confirmed(self, fp_confirmed:str=None, save_to_attribues:bool=True) -> pd.DataFrame:
+    def download_confirmed(self, fp_confirmed:str=None, save_to_attributes:bool=True) -> pd.DataFrame:
         """
         Attempts to download the most current data for the confirmed cases from the online repository of the
         Coronavirus Visual Dashboard operated by the Johns Hopkins University
@@ -94,11 +94,11 @@ class JHU():
             fp_confirmed = 'https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_global.csv'
 
         confirmed = self.__to_iso(self.__download_from_source(fp_confirmed))
-        if save_to_attribues:
+        if save_to_attributes:
             self.confirmed = confirmed
         return confirmed
 
-    def download_deaths(self, fp_deaths:str=None, save_to_attribues:bool=True) -> pd.DataFrame:
+    def download_deaths(self, fp_deaths:str=None, save_to_attributes:bool=True) -> pd.DataFrame:
         """
         Attempts to download the most current data for the deaths from the online repository of the
         Coronavirus Visual Dashboard operated by the Johns Hopkins University
@@ -121,11 +121,11 @@ class JHU():
             fp_deaths ='https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_deaths_global.csv'
 
         deaths = self.__to_iso(self.__download_from_source(fp_deaths))
-        if save_to_attribues:
+        if save_to_attributes:
             self.deaths = deaths
         return deaths
 
-    def download_recovered(self, fp_recovered:str=None, save_to_attribues:bool=True) -> pd.DataFrame:
+    def download_recovered(self, fp_recovered:str=None, save_to_attributes:bool=True) -> pd.DataFrame:
         """
         Attempts to download the most current data for the recovered cases from the online repository of the
         Coronavirus Visual Dashboard operated by the Johns Hopkins University
@@ -148,7 +148,7 @@ class JHU():
             fp_recovered = 'https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_recovered_global.csv'
 
         recovered = self.__to_iso(self.__download_from_source(fp_recovered))
-        if save_to_attribues:
+        if save_to_attributes:
             self.recovered = recovered
         return recovered
 
@@ -522,7 +522,7 @@ class JHU():
         """
         all_entrys = list(self.confirmed.columns) + list(self.deaths.columns) + list(self.recovered.columns)
         df = pd.DataFrame(all_entrys, columns = ['country', 'state']) 
-        df = df.groupby('country').apply(lambda x: x['state'].unique())
+
         return df
 
 class RKI():
@@ -643,15 +643,17 @@ class RKI():
         -------
         :pd.DataFrame
         """
-        # Set level for filter use bundesland if no landkreis is supplied else us landkreis
+        # Set level for filter use bundesland if no landkreis is supplied else use landkreis
         level = None
         value = None
-        if bundesland is not None:
+        if bundesland is not None and landkreis is None:
             level = "Bundesland"
             value = bundesland
-        if landkreis is not None:
+        elif bundesland is None and landkreis is not None:
             level = "Landkreis"
             value = landkreis
+        elif bundesland is not None and landkreis is not None:
+            raise ValueError('bundesland and landkreis cannot be simultaneously set.')
 
         df = self.filter(begin_date,end_date,'AnzahlFall',date_type,level,value)
         return df.drop(df.index[0])
@@ -679,12 +681,14 @@ class RKI():
         """        
         level = None
         value = None
-        if bundesland is not None:
+        if bundesland is not None and landkreis is None:
             level = "Bundesland"
             value = bundesland
-        if landkreis is not None:
+        elif bundesland is None and landkreis is not None:
             level = "Landkreis"
             value = landkreis
+        elif bundesland is not None and landkreis is not None:
+            raise ValueError('bundesland and landkreis cannot be simultaneously set.')
 
         df = self.filter(begin_date,end_date,'AnzahlFall',date_type,level,value)
         #Get difference to the days beforehand
@@ -714,12 +718,14 @@ class RKI():
         """
         level = None
         value = None
-        if bundesland is not None:
+        if bundesland is not None and landkreis is None:
             level = "Bundesland"
             value = bundesland
-        if landkreis is not None:
+        elif bundesland is None and landkreis is not None:
             level = "Landkreis"
             value = landkreis
+        elif bundesland is not None and landkreis is not None:
+            raise ValueError('bundesland and landkreis cannot be simultaneously set.')
 
         df = self.filter(begin_date,end_date,'AnzahlTodesfall',date_type,level,value)
         return df.drop(df.index[0])
@@ -748,12 +754,14 @@ class RKI():
         
         level = None
         value = None
-        if bundesland is not None:
+        if bundesland is not None and landkreis is None:
             level = "Bundesland"
             value = bundesland
-        if landkreis is not None:
+        elif bundesland is None and landkreis is not None:
             level = "Landkreis"
             value = landkreis
+        elif bundesland is not None and landkreis is not None:
+            raise ValueError('bundesland and landkreis cannot be simultaneously set.')
 
         df = self.filter(begin_date,end_date,'AnzahlTodesfall',date_type,level,value)
         #Get difference to the days beforehand
@@ -784,12 +792,14 @@ class RKI():
         # Set level for filter use bundesland if no landkreis is supplied else us landkreis
         level = None
         value = None
-        if bundesland is not None:
+        if bundesland is not None and landkreis is None:
             level = "Bundesland"
             value = bundesland
-        if landkreis is not None:
+        elif bundesland is None and landkreis is not None:
             level = "Landkreis"
             value = landkreis
+        elif bundesland is not None and landkreis is not None:
+            raise ValueError('bundesland and landkreis cannot be simultaneously set.')
 
         df = self.filter(begin_date,end_date,'AnzahlGenesen',date_type,level,value)
         return df.drop(df.index[0])

--- a/covid19_inference/data_retrieval.py
+++ b/covid19_inference/data_retrieval.py
@@ -26,6 +26,10 @@ class JHU():
     auto_download : bool, optional
         whether or not to automatically download the data from jhu (default: false)
 
+    TODO
+    ----
+    Add fallback sources (local copies)
+
     """
     def __init__(self, auto_download = False):
         self.confirmed : pd.DataFrame
@@ -35,21 +39,21 @@ class JHU():
         if auto_download:
             self.download_all_available_data()
 
-    def download_all_available_data(self,
-        fp_confirmed:str='https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_global.csv',
-        fp_deaths:str='https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_deaths_global.csv',
-        fp_recovered:str='https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_recovered_global.csv',
-        save_to_attributes:bool=True)-> (pd.DataFrame,pd.DataFrame,pd.DataFrame):
+    def download_all_available_data(self, fp_confirmed:str= None, fp_deaths:str=None, fp_recovered:str=None, save_to_attributes:bool=True) -> (pd.DataFrame,pd.DataFrame,pd.DataFrame):
         """
         Attempts to download the most current data for the confirmed cases, deaths and recovered cases from the online repository of the
         Coronavirus Visual Dashboard operated by the Johns Hopkins University
-        (and falls back to the backup provided with our repo if it fails TODO).
         Only works if the module is located in the repo directory.
 
         Parameters
         ----------
         fp_confirmed,fp_deaths,fp_recovered : str, optional
-            Filepath or URL pointing to the original CSV of global confirmed cases, deaths or recovered cases
+            |Filepath or URL pointing to the original CSV of global confirmed cases, deaths or recovered cases 
+            |default: None
+                Automatically uses the default sources
+                |https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_global.cs
+                |https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_deaths_global.csv
+                |https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_recovered_global.csv'
         save_to_attributes : bool, optional
             Should the returned dataframe tuple be saved as attributes (default:true)
 
@@ -58,13 +62,16 @@ class JHU():
         : pandas.DataFrame tuple
             tuple of table with confirmed, deaths and recovered cases
         """
-
+        #Check default for better visibility in the readthedocs page
+        if fp_confirmed is None:
+            fp_confirmed = 'https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_global.csv'
+        if fp_deaths is None:
+            fp_deaths ='https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_deaths_global.csv'
+        if fp_recovered is None:
+            fp_recovered = 'https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_recovered_global.csv'
         return self.download_confirmed(fp_confirmed, save_to_attributes), self.download_deaths(fp_deaths, save_to_attributes), self.download_recovered(fp_recovered, save_to_attributes)
 
-    def download_confirmed(self,
-        fp_confirmed:str='https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_global.csv',
-        save_to_attribues:bool=True
-        ):
+    def download_confirmed(self, fp_confirmed:str=None, save_to_attribues:bool=True) -> pd.DataFrame:
         """
         Attempts to download the most current data for the confirmed cases from the online repository of the
         Coronavirus Visual Dashboard operated by the Johns Hopkins University
@@ -76,22 +83,22 @@ class JHU():
         fp_confirmed : str, optional
             Filepath or URL pointing to the original CSV of global confirmed cases, deaths or recovered cases
         save_to_attributes : bool, optional
-            Should the returned dataframe tuple be saved as attributes (default:true)
+            Should the returned dataframe be saved as attributes (default:true)
 
         Returns
         -------
         : pandas.DataFrame
             Table with confirmed cases, indexed by date
         """
+        if fp_confirmed is None:
+            fp_confirmed = 'https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_global.csv'
+
         confirmed = self.__to_iso(self.__download_from_source(fp_confirmed))
         if save_to_attribues:
             self.confirmed = confirmed
         return confirmed
 
-    def download_deaths(self,
-        fp_deaths:str='https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_deaths_global.csv',
-        save_to_attribues:bool=True
-        ):
+    def download_deaths(self, fp_deaths:str=None, save_to_attribues:bool=True) -> pd.DataFrame:
         """
         Attempts to download the most current data for the deaths from the online repository of the
         Coronavirus Visual Dashboard operated by the Johns Hopkins University
@@ -103,22 +110,22 @@ class JHU():
         fp_deaths : str, optional
             filepath or URL pointing to the original CSV of global confirmed cases, deaths or recovered cases
         save_to_attributes : bool, optional
-            Should the returned dataframe tuple be saved as attributes (default:true)
+            Should the returned dataframe be saved as attributes (default:true)
 
         Returns
         -------
         : pandas.DataFrame
             Table with deaths, indexed by date
         """
+        if fp_deaths is None:
+            fp_deaths ='https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_deaths_global.csv'
+
         deaths = self.__to_iso(self.__download_from_source(fp_deaths))
         if save_to_attribues:
             self.deaths = deaths
         return deaths
 
-    def download_recovered(self,
-        fp_recovered:str='https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_recovered_global.csv',
-        save_to_attribues:bool=True
-        ):
+    def download_recovered(self, fp_recovered:str=None, save_to_attribues:bool=True) -> pd.DataFrame:
         """
         Attempts to download the most current data for the recovered cases from the online repository of the
         Coronavirus Visual Dashboard operated by the Johns Hopkins University
@@ -130,19 +137,22 @@ class JHU():
         fp_recovered : str, optional
             Filepath or URL pointing to the original CSV of global confirmed cases, deaths or recovered cases
         save_to_attributes : bool, optional
-            Should the returned dataframe tuple be saved as attributes (default:true)
+            Should the returned dataframe be saved as attributes (default:true)
 
         Returns
         -------
         : pandas.DataFrame
             Table with recovered cases, indexed by date
         """
+        if fp_recovered is None:
+            fp_recovered = 'https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_recovered_global.csv'
+
         recovered = self.__to_iso(self.__download_from_source(fp_recovered))
         if save_to_attribues:
             self.recovered = recovered
         return recovered
 
-    def __download_from_source(self, url, fallback = None)-> pd.DataFrame:
+    def __download_from_source(self, url, fallback = None) -> pd.DataFrame:
         """
         Private method
         Downloads one csv file from an url and converts it into a pandas dataframe. A fallback source can also be given.

--- a/covid19_inference/data_retrieval.py
+++ b/covid19_inference/data_retrieval.py
@@ -196,7 +196,7 @@ class JHU():
 
     def get_confirmed_deaths_recovered(self, country:str = None, state:str = None, begin_date:datetime.datetime = None, end_date:datetime.datetime = None) -> pd.DataFrame:
         """
-        Retrieves all confirmed, deaths and recovered Johns Hopkins University dataset as a DataFrame with datetime index.
+        Retrieves all confirmed, deaths and recovered cases from the Johns Hopkins University dataset as a DataFrame with datetime index.
         Can be filtered by country and state, if only a country is given all available states get summed up.
 
         Parameters
@@ -237,10 +237,8 @@ class JHU():
 
     def get_confirmed(self, country:str = None, state:str = None, begin_date:datetime.datetime = None, end_date:datetime.datetime = None) -> pd.DataFrame:
         """
-        Attempts to download the most current data for the confirmed cases from the online repository of the
-        Coronavirus Visual Dashboard operated by the Johns Hopkins University
-        and falls back to the backup provided with our repo if it fails.
-        Only works if the module is located in the repo directory.
+        Retrieves all confirmed cases from the Johns Hopkins University dataset as a DataFrame with datetime index.
+        Can be filtered by country and state, if only a country is given all available states get summed up.
 
         Parameters
         ----------
@@ -275,12 +273,35 @@ class JHU():
 
         return self.filter_date(df,begin_date,end_date)
 
+    def get_new_confirmed(self, country:str = None, state:str = None, begin_date:datetime.datetime = None, end_date:datetime.datetime = None) -> pd.DataFrame:
+        """
+        Retrieves all daily confirmed cases from the Johns Hopkins University dataset as a DataFrame with datetime index.
+        Can be filtered by country and state, if only a country is given all available states get summed up.
+
+        Parameters
+        ----------
+        country : str, optional
+            name of the country (the "Country/Region" column), can be None 
+        state : str, optional
+            name of the state (the "Province/State" column), can be None
+        begin_date : datetime.datetime, optional
+            intial date for the returned data, if no value is given the first date in the dataset is used
+        end_date : datetime.datetime, optional
+            last date for the returned data, if no value is given the most recent date in the dataset is used
+
+        Returns
+        -------
+        : pandas.DataFrame
+            table with daily new recovered cases and the date as index
+        """        
+        df = self.get_confirmed(country,state,begin_date,end_date)
+        df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
+        return df
+
     def get_deaths(self, country:str = None, state:str = None, begin_date:datetime.datetime = None, end_date:datetime.datetime = None) -> pd.DataFrame:
         """
-        Attempts to download the most current data for the confirmed deaths from the online repository of the
-        Coronavirus Visual Dashboard operated by the Johns Hopkins University
-        and falls back to the backup provided with our repo if it fails.
-        Only works if the module is located in the repo directory.
+        Retrieves all deaths from the Johns Hopkins University dataset as a DataFrame with datetime index.
+        Can be filtered by country and state, if only a country is given all available states get summed up.
 
         Parameters
         ----------
@@ -316,12 +337,35 @@ class JHU():
 
         return self.filter_date(df,begin_date,end_date)
 
+    def get_new_deaths(self, country:str = None, state:str = None, begin_date:datetime.datetime = None, end_date:datetime.datetime = None) -> pd.DataFrame:
+        """
+        Retrieves all daily deaths from the Johns Hopkins University dataset as a DataFrame with datetime index.
+        Can be filtered by country and state, if only a country is given all available states get summed up.
+
+        Parameters
+        ----------
+        country : str, optional
+            name of the country (the "Country/Region" column), can be None 
+        state : str, optional
+            name of the state (the "Province/State" column), can be None
+        begin_date : datetime.datetime, optional
+            intial date for the returned data, if no value is given the first date in the dataset is used
+        end_date : datetime.datetime, optional
+            last date for the returned data, if no value is given the most recent date in the dataset is used
+
+        Returns
+        -------
+        : pandas.DataFrame
+            table with daily new recovered cases and the date as index
+        """        
+        df = self.get_deaths(country,state,begin_date,end_date)
+        df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
+        return df
+
     def get_recovered(self, country:str = None, state:str = None, begin_date:datetime.datetime = None, end_date:datetime.datetime = None) -> pd.DataFrame:
         """
-        Attempts to download the most current data for the confirmed recoveries from the online repository of the
-        Coronavirus Visual Dashboard operated by the Johns Hopkins University
-        and falls back to the backup provided with our repo if it fails.
-        Only works if the module is located in the repo directory.
+        Retrieves all recovered cases from the Johns Hopkins University dataset as a DataFrame with datetime index.
+        Can be filtered by country and state, if only a country is given all available states get summed up.
 
         Parameters
         ----------
@@ -356,6 +400,31 @@ class JHU():
         df.index.name = 'date'
 
         return self.filter_date(df,begin_date,end_date)
+
+    def get_new_recovered(self, country:str = None, state:str = None, begin_date:datetime.datetime = None, end_date:datetime.datetime = None) -> pd.DataFrame:
+        """
+        Retrieves all daily recovered cases from the Johns Hopkins University dataset as a DataFrame with datetime index.
+        Can be filtered by country and state, if only a country is given all available states get summed up.
+
+        Parameters
+        ----------
+        country : str, optional
+            name of the country (the "Country/Region" column), can be None 
+        state : str, optional
+            name of the state (the "Province/State" column), can be None
+        begin_date : datetime.datetime, optional
+            intial date for the returned data, if no value is given the first date in the dataset is used
+        end_date : datetime.datetime, optional
+            last date for the returned data, if no value is given the most recent date in the dataset is used
+
+        Returns
+        -------
+        : pandas.DataFrame
+            table with daily new recovered cases and the date as index
+        """        
+        df = self.get_recovered(country,state,begin_date,end_date)
+        df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
+        return df
 
     def filter_date(self, df, begin_date:datetime.datetime = None, end_date:datetime.datetime = None) -> pd.DataFrame:
         """
@@ -411,9 +480,6 @@ class RKI():
         - filter by date
         see the methods in this class for more infos on the features and how to use them
 
-    ToDo:
-        - fix return of filter(...) function to be a pd.DataFrame instead of an array --> convention
-        - maybe if possible rewrite to code to use the same syntax as the jhu class (get_confirmed, get_confirmed_deaths_recovered, etc.)
     """
     def __init__(self, auto_download = False):
         self.data: pd.DataFrame
@@ -434,8 +500,7 @@ class RKI():
         : pandas.DataFrame
             Containing all the RKI data from arcgis website.
             In the format:
-            [Altersgruppe, AnzahlFall, AnzahlGenesen, AnzahlTodesfall, Bundesland, 
-            Geschlecht, Landkreis, Meldedatum, NeuGenesen, NeuerFall, Refdatum, date, date_ref]        
+                [Altersgruppe, AnzahlFall, AnzahlGenesen, AnzahlTodesfall, Bundesland, Geschlecht, Landkreis, Meldedatum, NeuGenesen, NeuerFall, Refdatum, date, date_ref]        
         '''
         landkreise_max=412#Strangely there are 412 regions defined by the Robert Koch Insitute in contrast to the offical 294 rural districts or the 401 administrative districts.
         url_id = 'https://services7.arcgis.com/mOBPykOjAyBO2ZKk/ArcGIS/rest/services/RKI_COVID19/FeatureServer/0/query?where=0%3D0&objectIds=&time=&resultType=none&outFields=idLandkreis&returnIdsOnly=false&returnUniqueIdsOnly=false&returnCountOnly=false&returnDistinctValues=true&cacheHint=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&having=&resultOffset=&resultRecordCount=&sqlFormat=none&f=pjson&token='
@@ -503,7 +568,7 @@ class RKI():
 
     def get_confirmed(self, bundesland:str = None, landkreis:str = None, begin_date:datetime.datetime = None, end_date:datetime.datetime = None, date_type:str='date')-> pd.DataFrame:
         """
-        Gets all total daily confirmed cases for a region as dataframe with date index. Can be filtered with multiple arguments.
+        Gets all total confirmed cases for a region as dataframe with date index. Can be filtered with multiple arguments.
         
         Parameters
         ----------
@@ -535,9 +600,35 @@ class RKI():
         df = self.filter(begin_date,end_date,'AnzahlFall',date_type,level,value)
         return df
 
-    def get_deaths(self, bundesland:str, landkreis:str, begin_date:datetime.datetime = None, end_date:datetime.datetime = None, date_type:str='date')-> pd.DataFrame:
+    def get_new_confirmed(self, bundesland:str = None, landkreis:str = None, begin_date:datetime.datetime = None, end_date:datetime.datetime = None, date_type:str='date')-> pd.DataFrame:
         """
-        Gets all total daily deaths for a region as dataframe with date index. Can be filtered with multiple arguments.
+        Retrieves all new confirmed cases daily from the Johns Hopkins University dataset as a DataFrame with datetime index.
+        Can be filtered by country and state, if only a country is given all available states get summed up.
+
+        Parameters
+        ----------
+        country : str, optional
+            name of the country (the "Country/Region" column), can be None 
+        state : str, optional
+            name of the state (the "Province/State" column), can be None
+        begin_date : datetime.datetime, optional
+            intial date for the returned data, if no value is given the first date in the dataset is used
+        end_date : datetime.datetime, optional
+            last date for the returned data, if no value is given the most recent date in the dataset is used
+
+        Returns
+        -------
+        : pandas.DataFrame
+            table with daily new confirmed and the date as index
+        """        
+        df = self.get_confirmed(bundesland, landkreis, begin_date, end_date, date_type)
+        #Get difference to the days beforehand
+        df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
+        return df
+
+    def get_deaths(self, bundesland:str = None, landkreis:str = None, begin_date:datetime.datetime = None, end_date:datetime.datetime = None, date_type:str='date')-> pd.DataFrame:
+        """
+        Gets all total deaths for a region as dataframe with date index. Can be filtered with multiple arguments.
         
         Parameters
         ----------
@@ -568,9 +659,35 @@ class RKI():
         df = self.filter(begin_date,end_date,'AnzahlTodesfall',date_type,level,value)
         return df
 
-    def get_recovered(self, bundesland:str, landkreis:str, begin_date:datetime.datetime = None, end_date:datetime.datetime = None, date_type:str='date')-> pd.DataFrame:
+    def get_new_deaths(self, bundesland:str = None, landkreis:str = None, begin_date:datetime.datetime = None, end_date:datetime.datetime = None, date_type:str='date')-> pd.DataFrame:
         """
-        Gets all total daily recovered cases as dataframe with date index. Can be filtered with multiple arguments.
+        Retrieves all new deaths daily from the Johns Hopkins University dataset as a DataFrame with datetime index.
+        Can be filtered by country and state, if only a country is given all available states get summed up.
+
+        Parameters
+        ----------
+        country : str, optional
+            name of the country (the "Country/Region" column), can be None 
+        state : str, optional
+            name of the state (the "Province/State" column), can be None
+        begin_date : datetime.datetime, optional
+            intial date for the returned data, if no value is given the first date in the dataset is used
+        end_date : datetime.datetime, optional
+            last date for the returned data, if no value is given the most recent date in the dataset is used
+
+        Returns
+        -------
+        : pandas.DataFrame
+            table with daily new deaths and the date as index
+        """        
+        df = self.get_deaths(bundesland, landkreis, begin_date, end_date, date_type)
+        #Get difference to the days beforehand
+        df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
+        return df
+
+    def get_recovered(self, bundesland:str = None, landkreis:str = None, begin_date:datetime.datetime = None, end_date:datetime.datetime = None, date_type:str='date')-> pd.DataFrame:
+        """
+        Gets all total recovered cases as dataframe with date index. Can be filtered with multiple arguments.
         
         Parameters
         ----------
@@ -600,6 +717,32 @@ class RKI():
             value = landkreis
 
         df = self.filter(begin_date,end_date,'AnzahlGenesen',date_type,level,value)
+        return df
+
+    def get_new_recovered(self, bundesland:str = None, landkreis:str = None, begin_date:datetime.datetime = None, end_date:datetime.datetime = None, date_type:str='date')-> pd.DataFrame:
+        """
+        Retrieves all new cases daily from the Johns Hopkins University dataset as a DataFrame with datetime index.
+        Can be filtered by country and state, if only a country is given all available states get summed up.
+
+        Parameters
+        ----------
+        country : str, optional
+            name of the country (the "Country/Region" column), can be None 
+        state : str, optional
+            name of the state (the "Province/State" column), can be None
+        begin_date : datetime.datetime, optional
+            intial date for the returned data, if no value is given the first date in the dataset is used
+        end_date : datetime.datetime, optional
+            last date for the returned data, if no value is given the most recent date in the dataset is used
+
+        Returns
+        -------
+        : pandas.DataFrame
+            table with daily new recovered cases and the date as index
+        """        
+        df = self.get_recovered(bundesland, landkreis, begin_date, end_date, date_type)
+        #Get difference to the days beforehand
+        df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
 
     def filter(self, begin_date:datetime.datetime = None, end_date:datetime.datetime = None, variable = 'AnzahlFall', date_type='date', level = None, value = None) -> pd.DataFrame:

--- a/covid19_inference/data_retrieval.py
+++ b/covid19_inference/data_retrieval.py
@@ -423,6 +423,7 @@ class JHU():
             table with daily new recovered cases and the date as index
         """        
         df = self.get_recovered(country,state,begin_date,end_date)
+
         df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
 
@@ -742,6 +743,7 @@ class RKI():
         """        
         df = self.get_recovered(bundesland, landkreis, begin_date, end_date, date_type)
         #Get difference to the days beforehand
+        print(df.index)
         df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
 
@@ -787,10 +789,11 @@ class RKI():
         if date_type not in ['date', 'date_ref']:
             raise ValueError('Invalid date_type. Valid options: "date", "date_ref"')
 
+        df = self.data.sort_values(date_type)
         if begin_date is None:
-            begin_date = self.data[date_type].iloc[0]
+            begin_date = df[date_type].iloc[0]
         if end_date is None:
-            end_date = self.data[date_type].iloc[-1]
+            end_date = df[date_type].iloc[-1]
 
         if not isinstance(begin_date, datetime.datetime) and isinstance(end_date, datetime.datetime):
             raise ValueError('Invalid begin_date, end_date: has to be datetime.datetime object')

--- a/covid19_inference/data_retrieval.py
+++ b/covid19_inference/data_retrieval.py
@@ -303,8 +303,16 @@ class JHU():
         -------
         : pandas.DataFrame
             table with daily new recovered cases and the date as index
-        """        
-        df = self.get_confirmed(country,state,begin_date,end_date)
+        """
+        if begin_date is not None:
+            begin_date = begin_date - datetime.timedelta(days=1)
+
+        df = self.get_confirmed(bundesland, landkreis, begin_date, end_date, date_type)
+        #Get difference to the days beforehand
+
+        #append a 0 row for consistency in the shape of the data output !HACKY!
+        if begin_date is None:
+            df.loc[pd.Timestamp.min.to_pydatetime()] = 0    
         df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
 
@@ -367,8 +375,17 @@ class JHU():
         -------
         : pandas.DataFrame
             table with daily new recovered cases and the date as index
-        """        
-        df = self.get_deaths(country,state,begin_date,end_date)
+        """
+        if begin_date is not None:
+            begin_date = begin_date - datetime.timedelta(days=1)
+
+        df = self.get_deaths(bundesland, landkreis, begin_date, end_date, date_type)
+        #Get difference to the days beforehand
+
+        #append a 0 row for consistency in the shape of the data output !HACKY!
+        if begin_date is None:
+            df.loc[pd.Timestamp.min.to_pydatetime()] = 0    
+
         df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
 
@@ -431,8 +448,17 @@ class JHU():
         -------
         : pandas.DataFrame
             table with daily new recovered cases and the date as index
-        """        
-        df = self.get_recovered(country,state,begin_date,end_date)
+        """
+        if begin_date is not None:
+            begin_date = begin_date - datetime.timedelta(days=1)
+
+        df = self.get_recovered(bundesland, landkreis, begin_date, end_date, date_type)
+        #Get difference to the days beforehand
+
+        #append a 0 row for consistency in the shape of the data output !HACKY!
+        if begin_date is None:
+            df.loc[pd.Timestamp.min.to_pydatetime()] = 0
+        #Get difference to the days beforehand
 
         df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
@@ -631,8 +657,16 @@ class RKI():
         -------
         : pandas.DataFrame
             table with daily new confirmed and the date as index
-        """        
-        df = self.get_confirmed(bundesland, landkreis, begin_date, end_date, date_type)
+        """
+        if begin_date is not None:
+            begin_date = begin_date - datetime.timedelta(days=1)
+
+        df = self.get_deaths(bundesland, landkreis, begin_date, end_date, date_type)
+        #Get difference to the days beforehand
+
+        #append a 0 row for consistency in the shape of the data output !HACKY!
+        if begin_date is None:
+            df.loc[pd.Timestamp.min.to_pydatetime()] = 0
         #Get difference to the days beforehand
         df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
@@ -690,8 +724,18 @@ class RKI():
         -------
         : pandas.DataFrame
             table with daily new deaths and the date as index
-        """        
+        """
+
+        if begin_date is not None:
+            begin_date = begin_date - datetime.timedelta(days=1)
+
         df = self.get_deaths(bundesland, landkreis, begin_date, end_date, date_type)
+        #Get difference to the days beforehand
+
+        #append a 0 row for consistency in the shape of the data output !HACKY!
+        if begin_date is None:
+            df.loc[pd.Timestamp.min.to_pydatetime()] = 0
+
         #Get difference to the days beforehand
         df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
@@ -751,9 +795,16 @@ class RKI():
         : pandas.DataFrame
             table with daily new recovered cases and the date as index
         """        
+        if begin_date is not None:
+            begin_date = begin_date - datetime.timedelta(days=1)
+
         df = self.get_recovered(bundesland, landkreis, begin_date, end_date, date_type)
         #Get difference to the days beforehand
-        print(df.index)
+
+        #append a 0 row for consistency in the shape of the data output !HACKY!
+        if begin_date is None:
+            df.loc[pd.Timestamp.min.to_pydatetime()] = 0
+
         df = df.diff().drop(df.index[0]).astype(int) # Neat oneliner to also drop the first row and set the type back to int 
         return df
 

--- a/docs/doc/gettingstarted.rst
+++ b/docs/doc/gettingstarted.rst
@@ -35,3 +35,11 @@ To get started, we recommend to look at one of the currently two example noteboo
 
 2. `Hierarchical model of the German states  <https://github.com/Priesemann-Group/covid19_inference/blob/master/scripts/example_bundeslaender.ipynb>`_
     This builds a hierarchical bayesian model of the states of Germany
+
+We can for example recommend the following articles about bayesian modeling:
+
+As a introduction to Bayesian statistics and the python package (PyMC3) that we use:
+https://docs.pymc.io/notebooks/api_quickstart.html
+
+This is a good post about hierarchical Bayesian models in general:
+https://statmodeling.stat.columbia.edu/2014/01/21/everything-need-know-bayesian-statistics-learned-eight-schools/

--- a/scripts/example_one_bundesland.ipynb
+++ b/scripts/example_one_bundesland.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +102,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "total_cases = rki.get_confirmed(bundesland=\"Sachsen\",begin_date='2020-03-10',end_date='2020-04-13')\n",
+    "#Create dates for filter\n",
+    "bd = datetime.datetime.strptime(\"2020-03-10\",'%y %m %d')\n",
+    "ed = datetime.datetime.strptime(\"2020-04-13\",'%y %m %d')\n",
+    "\n",
+    "total_cases = rki.get_confirmed(bundesland=\"Sachsen\",begin_date=bd,end_date=ed)\n",
     "new_cases = np.diff(np.array(total_cases))\n",
     "date_begin_data = datetime.datetime(2020,3,10)\n",
     "date_end_data   = datetime.datetime(2020,4,13)\n",


### PR DESCRIPTION
Fixes #8 

> that every filter function accepts datetime.datetime objects as begin and end date, and not strings

- Every method only accepts datetime.datetime objects as dates now 

> That the output of the JHU has datetime.datetime objects as index. I think that's what currently to iso function is doing.
- output dataframe was transposed somehow, because of that the __to_ios function and sums did not work as expected, should be fixed now

>  that the filter functions always return the new daily cases, and not the cumulative ones. That change would involve to calculate the difference in the jhu dataset. 
- added methods to get new daily cases source.get_new_* (confirmed,recovered,deaths) 
`df.diff`

> The data should then exclude the date date_begin, and include the date date_end (in order to have as length (date_end - date_begin).days).
- Not too sure what you mean by this, do you want to calculate the summed cases in the interval [begin_date, end_date]? With a reference to the period of time of the summed up cases (date_end - date_begin) in days?
I could create a method that does this.

Additionally added a method in the jhu source, that gives a list of all possible countries and states. 